### PR TITLE
Allow server hosts to be overriden in runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ storybook-static
 /tmp/
 screenshotsDiff/test.spec.js-snapshots   
 screenshotsDiff/test-results  
+.idea

--- a/common/const/Urls.ts
+++ b/common/const/Urls.ts
@@ -1,8 +1,12 @@
 // This is for important URLs to all kinds of services
 
 export const TOP_SERVER_HOST = process.env.TOP_SERVER_HOST!;
-export const APP_SERVER_HOST = process.env.APP_SERVER_HOST!;
-export const API_SERVER_HOST = process.env.API_SERVER_HOST!;
+export const APP_SERVER_HOST =
+  // @ts-expect-error
+  globalThis.CORD_APP_SERVER_HOST_OVERRIDE ?? process.env.APP_SERVER_HOST!;
+export const API_SERVER_HOST =
+  // @ts-expect-error
+  globalThis.CORD_API_SERVER_HOST_OVERRIDE ?? process.env.API_SERVER_HOST!;
 export const API_SERVER_HOST_PRODUCTION =
   process.env.API_SERVER_HOST_PRODUCTION!;
 export const ADMIN_SERVER_HOST = process.env.ADMIN_SERVER_HOST!;


### PR DESCRIPTION
Allow APP_SERVER_HOST and API_SERVER_HOST to be overridden in runtime. This aligns Cord's front-end SDK with how we inject our runtime configuration in Rows' front-end. 

In our front-end, we inject the configuration depending on the environment through the `window` object. This change allows our front-end to configure Cord's server hosts so we can dynamically switch where to load Cord from (and where its GraphQL endpoint will connect to).